### PR TITLE
Selected state bug

### DIFF
--- a/steam-reporter.py
+++ b/steam-reporter.py
@@ -31,7 +31,7 @@ def _email_connection(email_address, server, keyring_id, folder):
             return connection
         time.sleep(5)
     
-    sys.exit("Failed to select inbox folder.")
+    sys.exit("Timed out selecting inbox folder.")
 
 def _set_keyring_password(keyring_id, email_address):
     prompt = ("Enter password for %s: " % email_address)

--- a/steam-reporter.py
+++ b/steam-reporter.py
@@ -13,6 +13,7 @@ import sqlite3
 import os
 import command_args
 import time
+import sys
 
 def _email_connection(email_address, server, keyring_id, folder):
     connection = imaplib.IMAP4_SSL(server)
@@ -24,12 +25,13 @@ def _email_connection(email_address, server, keyring_id, folder):
             "password with the -p/--password flag.\n" % email_address)
         raise
 
-    while True:
+    for i in range(0, 12):
         connection.select(folder)
         if connection.state == 'SELECTED':
-            break
+            return connection
         time.sleep(5)
-    return connection
+    
+    sys.exit("Failed to select inbox folder.")
 
 def _set_keyring_password(keyring_id, email_address):
     prompt = ("Enter password for %s: " % email_address)

--- a/steam-reporter.py
+++ b/steam-reporter.py
@@ -12,6 +12,7 @@ import tempfile
 import sqlite3
 import os
 import command_args
+import time
 
 def _email_connection(email_address, server, keyring_id, folder):
     connection = imaplib.IMAP4_SSL(server)
@@ -23,7 +24,11 @@ def _email_connection(email_address, server, keyring_id, folder):
             "password with the -p/--password flag.\n" % email_address)
         raise
 
-    connection.select(folder)
+    while True:
+        connection.select(folder)
+        if connection.state == 'SELECTED':
+            break
+        time.sleep(5)
     return connection
 
 def _set_keyring_password(keyring_id, email_address):


### PR DESCRIPTION
If fetching many email files, there was a high probability of a email failing to be properly fetched. This was due to `connection.select(folder)` failing to select the folder, leaving the state in `AUTH` and causing fetch to fail. 

This adds a retry and timeout for folder selection. `sys.exit()` will be called upon timeout. This has an added benefit of not having to wait until the email fetching has completed before spitting out an error.